### PR TITLE
Make sure that autoabr handles AWS errors gracefully

### DIFF
--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -5,6 +5,7 @@ import { Pipeline } from '../pipelines/pipeline';
 import suggestLadder from '../suggest-ladder';
 import path from 'path';
 import { BitrateResolutionVMAF } from '../models/bitrate-resolution-vmaf';
+import logger from '../logger';
 
 export type AnalysisOptions = {
   models?: QualityAnalysisModel[];
@@ -107,6 +108,11 @@ export default async function analyzeBruteForce(
       `${directory}/${pair.resolution.width}x${pair.resolution.height}_${pair.bitrate}.mp4`
     );
 
+    if (variant === '') {
+      logger.error(`Error transcoding ${reference}`);
+      return [];
+    }
+
     const qualityFile = variant.replace('.mp4', '_vmaf.json');
 
     if (concurrency) {
@@ -137,6 +143,11 @@ export default async function analyzeBruteForce(
       return results;
     }
   };
+
+  if (analyzePair.length === 0) {
+    logger.error(`No pairs to analyze`);
+    return [];
+  }
 
   let qualityFiles = new Map<QualityAnalysisModel, string[]>();
   if (concurrency === true) {

--- a/src/create-job.ts
+++ b/src/create-job.ts
@@ -94,7 +94,6 @@ export default async function createJob(description: JobDescription, pipelineDat
   let pipeline: any = undefined;
   if (pipelineData && encodingProfileData) {
     pipeline = (await loadPipelineFromObjects(pipelineData, encodingProfileData)) as AWSPipeline;
-    logger.info('AWS pipeline: ' + JSON.stringify(pipeline));
   } else {
     pipeline = (await loadPipeline(description.pipeline, description.encodingProfile)) as AWSPipeline;
   }


### PR DESCRIPTION
Fixes: #14 

This PR includes a fix that ensures that no task is started in ECS if a MediaConvert job have failed. 