### PR TITLE
feat: Added support for specifying bitrate range for individual resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,16 @@ To generate VMAF measurements, you will need to define a job which can be create
     pipeline: "pipeline.yml",
     encodingProfile: "profile.json",
     reference: "reference.mp4",
-    models: ["HD", "PhoneHD"],                       // optional
-    resolutions: [{ width: 1280, height: 720 }],     // optional
-    bitrates: [600000],                              // optional
-    method: "bruteForce"                             // optional
+    models: ["HD", "PhoneHD"],         // optional
+    resolutions: [{                    // optional
+      width: 1280,      
+      height: 720, 
+      range:                           // optional
+         { min: 500000, 
+         max: 600000 } 
+   }],                                                
+    bitrates: [500000, 600000],        // optional
+    method: "bruteForce"               // optional
   });
 ```
 
@@ -90,6 +96,8 @@ When creating a job, you can specify:
     * A list of VMAF-models to use in evaluation. This can be HD, MobileHD and UHD. HD by default.
  * **Resolutions** (optional)
     * A list of resolutions to test. By default it will test all resolutions in the example ABR-ladder provided by Apple in the [HLS Authoring Spec](https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices).
+    * **Range** (optional)
+       * A min and max bitrate for testing a specific resolution. Adding a range will filter out bitrates that are outside of the given range. It is disabled by default. 
  * **Bitrates** (optional)
     * A list of bitrates to test. By default a list of bitrates between 150 kbit/s to 9000 kbit/s.
  * **Method** (optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/client-s3": "^3.36.0",
         "@aws-sdk/credential-providers": "^3.36.0",
         "@aws-sdk/lib-storage": "^3.36.0",
+        "@eyevinn/autovmaf": "^0.3.2",
         "@types/aws-lambda": "^8.10.86",
         "aws-sdk": "^2.1123.0",
         "fluent-ffmpeg": "^2.1.2",
@@ -3129,6 +3130,25 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@eyevinn/autovmaf": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eyevinn/autovmaf/-/autovmaf-0.3.2.tgz",
+      "integrity": "sha512-16gORpwcSKiEFVsqZYgxMTgansUZF12BoavXkB3C0xeuqgfiAdGjeBywfHzdj7JbYdj6SJx9fNLO0U15uOzRzg==",
+      "dependencies": {
+        "@aws-sdk/client-ecs": "^3.36.0",
+        "@aws-sdk/client-mediaconvert": "^3.36.0",
+        "@aws-sdk/client-s3": "^3.36.0",
+        "@aws-sdk/credential-providers": "^3.36.0",
+        "@aws-sdk/lib-storage": "^3.36.0",
+        "@types/aws-lambda": "^8.10.86",
+        "aws-sdk": "^2.1123.0",
+        "fluent-ffmpeg": "^2.1.2",
+        "papaparse": "^5.3.1",
+        "typedoc": "^0.22.15",
+        "winston": "^3.3.3",
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -9789,6 +9809,25 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "@eyevinn/autovmaf": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eyevinn/autovmaf/-/autovmaf-0.3.2.tgz",
+      "integrity": "sha512-16gORpwcSKiEFVsqZYgxMTgansUZF12BoavXkB3C0xeuqgfiAdGjeBywfHzdj7JbYdj6SJx9fNLO0U15uOzRzg==",
+      "requires": {
+        "@aws-sdk/client-ecs": "^3.36.0",
+        "@aws-sdk/client-mediaconvert": "^3.36.0",
+        "@aws-sdk/client-s3": "^3.36.0",
+        "@aws-sdk/credential-providers": "^3.36.0",
+        "@aws-sdk/lib-storage": "^3.36.0",
+        "@types/aws-lambda": "^8.10.86",
+        "aws-sdk": "^2.1123.0",
+        "fluent-ffmpeg": "^2.1.2",
+        "papaparse": "^5.3.1",
+        "typedoc": "^0.22.15",
+        "winston": "^3.3.3",
+        "yaml": "^1.10.2"
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@aws-sdk/client-s3": "^3.36.0",
     "@aws-sdk/credential-providers": "^3.36.0",
     "@aws-sdk/lib-storage": "^3.36.0",
-    "@eyevinn/autovmaf": "^0.3.2",
     "@types/aws-lambda": "^8.10.86",
     "aws-sdk": "^2.1123.0",
     "fluent-ffmpeg": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git+https://github.com/Eyevinn/autovmaf.git"
   },
-  "keywords": ["vmaf"],
+  "keywords": [
+    "vmaf"
+  ],
   "contributors": [
     "Oscar Nord <oscar.nord@eyevinn.se> (Eyevinn Technology AB)",
     "Jonathan Walter <jonathan.walter@eyevinn.se> (Eyevinn Technology AB)"
@@ -26,8 +28,8 @@
     "docs": "npx typedoc src/index.ts"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.16.7",
     "@babel/preset-env": "^7.17.10",
+    "@babel/preset-typescript": "^7.16.7",
     "@types/fluent-ffmpeg": "^2.1.18",
     "@types/jest": "^27.5.0",
     "@types/papaparse": "^5.3.1",
@@ -42,6 +44,7 @@
     "@aws-sdk/client-s3": "^3.36.0",
     "@aws-sdk/credential-providers": "^3.36.0",
     "@aws-sdk/lib-storage": "^3.36.0",
+    "@eyevinn/autovmaf": "^0.3.2",
     "@types/aws-lambda": "^8.10.86",
     "aws-sdk": "^2.1123.0",
     "fluent-ffmpeg": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "contributors": [
     "Oscar Nord <oscar.nord@eyevinn.se> (Eyevinn Technology AB)",
-    "Jonathan Walter <jonathan.walter@eyevinn.se> (Eyevinn Technology AB)"
+    "Jonathan Walter <jonathan.walter@eyevinn.se> (Eyevinn Technology AB)",
+    "Robin Olsson <robin.olsson@eyevinn.se> (Eyevinn Technology AB)"
   ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -53,11 +53,11 @@ const defaultBitrates = [
 ];
 
 const defaultResolutions: Resolution[] = [
-  { width: 640, height: 360 },
-  { width: 768, height: 432 },
-  { width: 960, height: 540 },
-  { width: 1280, height: 720 },
-  { width: 1920, height: 1080 },
+  { width: 640, height: 360, range: undefined},
+  { width: 768, height: 432, range: undefined},
+  { width: 960, height: 540, range: undefined},
+  { width: 1280, height: 720, range: undefined},
+  { width: 1920, height: 1080, range: undefined},
 ];
 
 const defaultFilterFunction: (pair: BitrateResolutionPair) => boolean = ({ bitrate, resolution }) =>
@@ -84,7 +84,7 @@ export default async function analyzeBruteForce(directory: string, reference: st
     .flat()
     .flatMap(resolution =>
       bitrates.map(bitrate =>
-        filterFunction({ bitrate, resolution })
+        (filterFunction({ bitrate, resolution }) && checkIfRangeSetAndBitrateInRange(bitrate, resolution)) 
           ? {
               resolution,
               bitrate,
@@ -155,4 +155,15 @@ export default async function analyzeBruteForce(directory: string, reference: st
       });
     }
   }
+}
+
+function checkIfRangeSetAndBitrateInRange(bitrate: number, resolution: Resolution): boolean {
+  if(resolution.range === undefined) {
+    return true;
+  }
+
+  if((bitrate >= resolution.range.min && bitrate <= resolution.range.max)) {
+    return true;
+  } 
+  return false;
 }

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -160,10 +160,9 @@ export default async function analyzeBruteForce(directory: string, reference: st
 function checkIfRangeSetAndBitrateInRange(bitrate: number, resolution: Resolution): boolean {
   if(resolution.range === undefined) {
     return true;
-  }
-
-  if((bitrate >= resolution.range.min && bitrate <= resolution.range.max)) {
+  } else if(bitrate >= resolution.range.min && bitrate <= resolution.range.max) {
     return true;
-  } 
+  } else {
   return false;
+  }
 }

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -52,11 +52,11 @@ const defaultBitrates = [
 ];
 
 const defaultResolutions: Resolution[] = [
-  { width: 640, height: 360, range: undefined},
-  { width: 768, height: 432, range: undefined},
-  { width: 960, height: 540, range: undefined},
-  { width: 1280, height: 720, range: undefined},
-  { width: 1920, height: 1080, range: undefined},
+  { width: 640, height: 360},
+  { width: 768, height: 432},
+  { width: 960, height: 540},
+  { width: 1280, height: 720},
+  { width: 1920, height: 1080},
 ];
 
 const defaultFilterFunction: (pair: BitrateResolutionPair) => boolean = ({ bitrate, resolution }) =>
@@ -168,7 +168,7 @@ export function preparePairs(resolutions: Resolution[], bitrates: number[], filt
 }
 
 function checkIfBitrateInRange(bitrate: number, range: BitrateRange): boolean {
-  let minBitrate = range?.min != undefined ? range.min : defaultBitrates[0];
-  let maxBitrate = range?.max != undefined ? range.max : defaultBitrates[defaultBitrates.length - 1];
+  let minBitrate = range.min ? range.min : defaultBitrates[0];
+  let maxBitrate = range.max ? range.max : defaultBitrates[defaultBitrates.length - 1];
   return bitrate >= minBitrate && bitrate <= maxBitrate ? true : false;
 }

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -2,9 +2,7 @@ import { BitrateResolutionPair } from '../models/bitrate-resolution-pair';
 import { QualityAnalysisModel, qualityAnalysisModelToString } from '../models/quality-analysis-model';
 import { Resolution } from '../models/resolution';
 import { Pipeline } from '../pipelines/pipeline';
-import suggestLadder from '../suggest-ladder';
 import path from 'path';
-import { BitrateResolutionVMAF } from '../models/bitrate-resolution-vmaf';
 import logger from '../logger';
 import { BitrateRange } from '../models/bitrateRange';
 

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -168,7 +168,7 @@ export function preparePairs(resolutions: Resolution[], bitrates: number[], filt
 }
 
 function checkIfBitrateInRange(bitrate: number, range: BitrateRange): boolean {
-  let minBitrate = range?.min != undefined ? range.min : 0;
-  let maxBitrate = range?.max != undefined ? range.max : 90000000;
+  let minBitrate = range?.min != undefined ? range.min : defaultBitrates[0];
+  let maxBitrate = range?.max != undefined ? range.max : defaultBitrates[defaultBitrates.length - 1];
   return bitrate >= minBitrate && bitrate <= maxBitrate ? true : false;
 }

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -168,5 +168,7 @@ export function preparePairs(resolutions: Resolution[], bitrates: number[], filt
 }
 
 function checkIfBitrateInRange(bitrate: number, range: BitrateRange): boolean {
-    return bitrate >= range?.min && bitrate <= range.max ? true : false;
+  let minBitrate = range?.min != undefined ? range.min : 0;
+  let maxBitrate = range?.max != undefined ? range.max : 90000000;
+  return bitrate >= minBitrate && bitrate <= maxBitrate ? true : false;
 }

--- a/src/analysis/brute-force.ts
+++ b/src/analysis/brute-force.ts
@@ -149,9 +149,9 @@ export default async function analyzeBruteForce(directory: string, reference: st
 /**
  * Prepares the resolution-bitrate pairs to be analyzed.
  *
- * @param resolutions The different resolutions to be analyzed. Also contains the bitrate range
+ * @param resolutions The different resolutions to be analyzed. Also contains the bitrate range.
  * @param bitrates A list of bitrates that can analyzed.
- * @param filterFunction .
+ * @param filterFunction A filter function to be used for filtering out bitrates.
  */
 export function preparePairs(resolutions: Resolution[], bitrates: number[], filterFunction: (pair: BitrateResolutionPair) => boolean): BitrateResolutionPair[] {
   return resolutions

--- a/src/create-job.ts
+++ b/src/create-job.ts
@@ -1,19 +1,14 @@
-import fs from 'fs';
 import analyzeBruteForce from './analysis/brute-force';
 import { Pipeline } from './pipelines/pipeline'
 import AWSPipeline from './pipelines/aws/aws-pipeline';
 import { loadPipeline, loadPipelineFromObjects } from './load-pipeline';
 import {
   QualityAnalysisModel,
-  qualityAnalysisModelToString,
   stringToQualityAnalysisModel,
 } from './models/quality-analysis-model';
 import logger from './logger';
-import Papa from 'papaparse';
 import { Resolution } from './models/resolution';
 import analyzeWalkTheHull from './analysis/walk-the-hull';
-import { BitrateResolutionVMAF } from './models/bitrate-resolution-vmaf';
-import { BitrateRange } from './models/bitrateRange';
 
 /** Describes a ABR-analysis job and can be used to create jobs using the createJob()-function. */
 export type JobDescription = {

--- a/src/create-job.ts
+++ b/src/create-job.ts
@@ -54,8 +54,23 @@ export type JobDescription = {
  *   encodingProfile: "profile.json",
  *   reference: "reference.mp4",
  *   models: ["HD", "PhoneHD"],
- *   resolutions: [{ width: 1280, height: 720 }],
+ *   resolutions: [{ width: 1280, height: 720, range: undefined }],
  *   bitrates: [600000],
+ *   method: "bruteForce"
+ * });
+ * ```
+ * @example **Example of creating a job from a job description with range set.**
+ * ```javascript
+ * const { createJob, qualityAnalysisModelToString } = require('@eyevinn/autovmaf');
+ *
+ * const abrLadder = await = createJob({
+ *   name: "hello",
+ *   pipeline: "pipeline.yml",
+ *   encodingProfile: "profile.json",
+ *   reference: "reference.mp4",
+ *   models: ["HD", "PhoneHD"],
+ *   resolutions: [{ width: 1280, height: 720, range: { min: 400000, max: 600000} }],
+ *   bitrates: [400000, 600000, 800000],
  *   method: "bruteForce"
  * });
  * ```
@@ -129,5 +144,3 @@ export default async function createJob(description: JobDescription, pipelineDat
 
   logger.info('Finished analysis!');
 }
-
-

--- a/src/create-job.ts
+++ b/src/create-job.ts
@@ -12,6 +12,7 @@ import Papa from 'papaparse';
 import { Resolution } from './models/resolution';
 import analyzeWalkTheHull from './analysis/walk-the-hull';
 import { BitrateResolutionVMAF } from './models/bitrate-resolution-vmaf';
+import { BitrateRange } from './models/bitrateRange';
 
 /** Describes a ABR-analysis job and can be used to create jobs using the createJob()-function. */
 export type JobDescription = {
@@ -117,8 +118,8 @@ export default async function createJob(description: JobDescription, pipelineDat
     await analyzeWalkTheHull();
   } else {
     await analyzeBruteForce(description.name, reference, pipeline, {
-      bitrates: description.bitrates,
       resolutions: description.resolutions,
+      bitrates: description.bitrates,
       concurrency: true,
       models,
       filterFunction:
@@ -128,3 +129,5 @@ export default async function createJob(description: JobDescription, pipelineDat
 
   logger.info('Finished analysis!');
 }
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { BitrateResolutionVMAF } from './models/bitrate-resolution-vmaf';
 import { AWSPipelineConfiguration } from './pipelines/aws/aws-pipeline-configuration';
 import { LocalPipelineConfiguration } from './pipelines/local/local-pipeline-configuration';
 import { Resolution } from './models/resolution';
+import { BitrateRange } from './models/bitrateRange';
 import getVmaf from './get-vmaf';
 import createJob, { JobDescription } from './create-job';
 import {
@@ -33,6 +34,7 @@ export {
   AWSPipeline,
   BitrateResolutionVMAF,
   Resolution,
+  BitrateRange,
   LocalPipelineConfiguration,
   AWSPipelineConfiguration,
   logger,

--- a/src/models/bitrateRange.ts
+++ b/src/models/bitrateRange.ts
@@ -1,4 +1,4 @@
 export type BitrateRange = {
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
 };

--- a/src/models/bitrateRange.ts
+++ b/src/models/bitrateRange.ts
@@ -1,5 +1,4 @@
 export type BitrateRange = {
     min: number;
-    step?: number; // Not yet implemented
     max: number;
 };

--- a/src/models/bitrateRange.ts
+++ b/src/models/bitrateRange.ts
@@ -1,0 +1,5 @@
+export type BitrateRange = {
+    min: number;
+    step?: number; // Not yet implemented
+    max: number;
+};

--- a/src/models/resolution.ts
+++ b/src/models/resolution.ts
@@ -1,4 +1,7 @@
+import { BitrateRange } from "./bitrateRange";
+
 export type Resolution = {
   width: number;
   height: number;
+  range?: BitrateRange;
 };

--- a/tests/brute-force.test.ts
+++ b/tests/brute-force.test.ts
@@ -1,0 +1,47 @@
+import { 
+    jobWithBitratesAndRangeSet, 
+    defaultFilterFunction, 
+    jobWithoutBitrates, 
+    jobWithoutBitratesAndRange, 
+    defaultBitrates,
+    defaultResolutions,
+    numberOfDefaultBitratesAfterDefaultFilter
+} from "./resources/brute-force.test.data";
+import { preparePairs } from '../src/analysis/brute-force';
+import { Resolution } from "../src/models/resolution";
+import { BitrateRange, JobDescription } from "../src";
+import { BitrateResolutionPair } from '../src/models/bitrate-resolution-pair';
+
+describe('preparePairs', () => {
+    test('with bitrates and range set should filter out resolutions outside of range', () => {
+        let testData = prepareTestData(jobWithBitratesAndRangeSet);
+        
+        testData.pairs.forEach(pair => {
+            expect(pair.bitrate).toBeGreaterThanOrEqual(testData.range.min);
+            expect(pair.bitrate).toBeLessThanOrEqual(testData.range.max);
+        })
+    });
+
+    test('without bitrates but range set should filter out resolutions outside of range', () => {
+        let testData = prepareTestData(jobWithoutBitrates);
+        
+        testData.pairs.forEach(pair => {
+            expect(pair.bitrate).toBeGreaterThanOrEqual(testData.range.min);
+            expect(pair.bitrate).toBeLessThanOrEqual(testData.range.max);
+        })
+    });
+
+    test('without bitrates and range set should not filter out any bitrates', () => {
+        let testData = prepareTestData(jobWithoutBitratesAndRange);
+        console.log(testData.pairs);
+        expect(testData.pairs.length).toEqual(numberOfDefaultBitratesAfterDefaultFilter);
+    });
+
+  });
+
+function prepareTestData(jobDescription: JobDescription): {pairs: BitrateResolutionPair[], range: BitrateRange} {
+    let resolutions: Resolution[] = jobDescription.resolutions != undefined ? jobDescription.resolutions : defaultResolutions;
+    let bitrates = jobDescription.bitrates != undefined ? jobDescription.bitrates : defaultBitrates;
+    let range: BitrateRange = resolutions[0].range != undefined ? resolutions[0].range : {min: 0, max: 0};
+    return {pairs: preparePairs(resolutions, bitrates, defaultFilterFunction), range: range};
+}

--- a/tests/brute-force.test.ts
+++ b/tests/brute-force.test.ts
@@ -3,6 +3,8 @@ import {
     defaultFilterFunction, 
     jobWithoutBitrates, 
     jobWithoutBitratesAndRange, 
+    jobWithBitratesAndMinRangeSet,
+    jobWithBitratesAndMaxRangeSet,
     defaultBitrates,
     defaultResolutions,
     numberOfDefaultBitratesAfterDefaultFilter
@@ -17,17 +19,37 @@ describe('preparePairs', () => {
         let testData = prepareTestData(jobWithBitratesAndRangeSet);
         
         testData.pairs.forEach(pair => {
-            expect(pair.bitrate).toBeGreaterThanOrEqual(testData.range.min);
-            expect(pair.bitrate).toBeLessThanOrEqual(testData.range.max);
+            expect(pair.bitrate).toBeGreaterThanOrEqual(getMinBitrate(testData));
+            expect(pair.bitrate).toBeLessThanOrEqual(getMaxBitrate(testData));
         })
+    });
+
+    test('with bitrates and min range set should filter out resolutions below range', () => {
+        let testData = prepareTestData(jobWithBitratesAndMinRangeSet);
+        
+        testData.pairs.forEach(pair => {
+            expect(pair.bitrate).toBeGreaterThanOrEqual(getMinBitrate(testData));
+            expect(pair.bitrate).toBeLessThanOrEqual(getMaxBitrate(testData));
+        })
+        expect(testData.pairs.length).toEqual(2);
+    });
+
+    test('with bitrates and max range set should filter out resolutions above range', () => {
+        let testData = prepareTestData(jobWithBitratesAndMaxRangeSet);
+        
+        testData.pairs.forEach(pair => {
+            expect(pair.bitrate).toBeGreaterThanOrEqual(getMinBitrate(testData));
+            expect(pair.bitrate).toBeLessThanOrEqual(getMaxBitrate(testData));
+        })
+        expect(testData.pairs.length).toEqual(2);
     });
 
     test('without bitrates but range set should filter out resolutions outside of range', () => {
         let testData = prepareTestData(jobWithoutBitrates);
         
         testData.pairs.forEach(pair => {
-            expect(pair.bitrate).toBeGreaterThanOrEqual(testData.range.min);
-            expect(pair.bitrate).toBeLessThanOrEqual(testData.range.max);
+            expect(pair.bitrate).toBeGreaterThanOrEqual(getMinBitrate(testData));
+            expect(pair.bitrate).toBeLessThanOrEqual(getMaxBitrate(testData));
         })
     });
 
@@ -42,6 +64,15 @@ describe('preparePairs', () => {
 function prepareTestData(jobDescription: JobDescription): {pairs: BitrateResolutionPair[], range: BitrateRange} {
     let resolutions: Resolution[] = jobDescription.resolutions != undefined ? jobDescription.resolutions : defaultResolutions;
     let bitrates = jobDescription.bitrates != undefined ? jobDescription.bitrates : defaultBitrates;
-    let range: BitrateRange = resolutions[0].range != undefined ? resolutions[0].range : {min: 0, max: 0};
+    let range: BitrateRange = resolutions[0].range != undefined ? resolutions[0].range : {min: 0, max: 90000000};
+
     return {pairs: preparePairs(resolutions, bitrates, defaultFilterFunction), range: range};
+}
+
+function getMinBitrate(testData): number {
+    return testData.range.min !== undefined ? testData.range.min : 0;
+}
+
+function getMaxBitrate(testData): number {
+    return testData.range.max !== undefined ? testData.range.max : 90000000;
 }

--- a/tests/brute-force.test.ts
+++ b/tests/brute-force.test.ts
@@ -55,7 +55,6 @@ describe('preparePairs', () => {
 
     test('without bitrates and range set should not filter out any bitrates', () => {
         let testData = prepareTestData(jobWithoutBitratesAndRange);
-        console.log(testData.pairs);
         expect(testData.pairs.length).toEqual(numberOfDefaultBitratesAfterDefaultFilter);
     });
 

--- a/tests/create-job.test.ts
+++ b/tests/create-job.test.ts
@@ -14,8 +14,8 @@ const job: JobDescription = {
   encodingProfile: "profile.json",
   reference: "reference.mp4",
   models: ["HD", "PhoneHD"],
-  resolutions: [{ width: 1280, height: 720 }],
-  bitrates: [600000],
+  resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
+  bitrates: [400000, 600000, 800000],
   method: "bruteForce"
 };
 const pipeline = {

--- a/tests/create-job.test.ts
+++ b/tests/create-job.test.ts
@@ -2,81 +2,12 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { CreateJobCommand, MediaConvertClient } from '@aws-sdk/client-mediaconvert';
 import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { ECSClient, RunTaskCommand } from '@aws-sdk/client-ecs';
-import createJob, { JobDescription } from '../src/create-job';
+import createJob from '../src/create-job';
+import { job, pipeline, encodingSettings } from './resources/create-job.test.data'
 
 const mcMock = mockClient(MediaConvertClient);
 const ecsMock = mockClient(ECSClient);
 const s3Mock = mockClient(S3Client);
-
-const job: JobDescription = {
-  name: "test-job",
-  pipeline: "pipeline.yml",
-  encodingProfile: "profile.json",
-  reference: "reference.mp4",
-  models: ["HD", "PhoneHD"],
-  resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
-  bitrates: [400000, 600000, 800000],
-  method: "bruteForce"
-};
-const pipeline = {
-  aws: {
-    s3Bucket: 'vmaf-files',
-    mediaConvertRole: 'arn:aws:iam::1234:role/MediaConvert_Default_Role',
-    mediaConvertEndpoint: 'https://abc123xyz.mediaconvert.eu-north-1.amazonaws.com',
-    ecsSubnet: 'subnet-05d98882c13408e16',
-    ecsSecurityGroup: 'sg-0e444b67a747bf739',
-    ecsContainerName: 'easyvmaf-s3',
-    ecsCluster: 'vmaf-runner',
-    ecsTaskDefinition: 'easyvmaf-s3:1',
-  },
-};
-const encodingSettings = {
-  Inputs: [
-    {
-      TimecodeSource: 'ZEROBASED',
-      VideoSelector: {},
-      FileInput: '$INPUT',
-    },
-  ],
-  OutputGroups: [
-    {
-      Name: 'File Group',
-      OutputGroupSettings: {
-        Type: 'FILE_GROUP_SETTINGS',
-        FileGroupSettings: {
-          Destination: '$OUTPUT',
-        },
-      },
-      Outputs: [
-        {
-          VideoDescription: {
-            CodecSettings: {
-              Codec: 'H_265',
-              H265Settings: {
-                GopBReference: 'ENABLED',
-                HrdBufferSize: '$HRDBUFFER',
-                Bitrate: '$BITRATE',
-                RateControlMode: 'CBR',
-                CodecProfile: 'MAIN10_HIGH',
-                AdaptiveQuantization: 'AUTO',
-                GopSizeUnits: 'AUTO',
-              },
-            },
-            Width: '$WIDTH',
-            Height: '$HEIGHT',
-          },
-          ContainerSettings: {
-            Container: 'MP4',
-            Mp4Settings: {},
-          },
-        },
-      ],
-    },
-  ],
-  TimecodeConfig: {
-    Source: 'ZEROBASED',
-  },
-};
 
 beforeEach(() => {
   mcMock.reset();
@@ -91,7 +22,6 @@ afterEach(() => {
   delete process.env.LOAD_CREDENTIALS_FROM_ENV;
 });
 
-
 describe('create-job', () => {
   it('should create a job successfully', async () => {
     s3Mock.on(HeadObjectCommand).resolves({});
@@ -104,3 +34,6 @@ describe('create-job', () => {
     expect(mcMock.send).toHaveBeenCalled;
   });
 });
+
+
+

--- a/tests/resources/brute-force.test.data.ts
+++ b/tests/resources/brute-force.test.data.ts
@@ -25,7 +25,6 @@ export const jobWithoutBitrates: JobDescription = {
     reference: "reference.mp4",
     models: ["HD", "PhoneHD"],
     resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
-    bitrates: undefined,
     method: "bruteForce"
   };
 
@@ -35,8 +34,7 @@ export const jobWithoutBitratesAndRange: JobDescription = {
     encodingProfile: "profile.json",
     reference: "reference.mp4",
     models: ["HD", "PhoneHD"],
-    resolutions: [{ width: 1280, height: 720, range: undefined} ],
-    bitrates: undefined,
+    resolutions: [{ width: 1280, height: 720} ],
     method: "bruteForce"
   };
 
@@ -46,7 +44,7 @@ export const jobWithoutBitratesAndRange: JobDescription = {
     encodingProfile: "profile.json",
     reference: "reference.mp4",
     models: ["HD", "PhoneHD"],
-    resolutions: [{ width: 1280, height: 720, range: {min: 600000, max: undefined}} ],
+    resolutions: [{ width: 1280, height: 720, range: {min: 600000}} ],
     bitrates: [400000, 600000, 800000],
     method: "bruteForce"
   }; 
@@ -57,7 +55,7 @@ export const jobWithoutBitratesAndRange: JobDescription = {
     encodingProfile: "profile.json",
     reference: "reference.mp4",
     models: ["HD", "PhoneHD"],
-    resolutions: [{ width: 1280, height: 720, range: {min: undefined, max: 600000}} ],
+    resolutions: [{ width: 1280, height: 720, range: {max: 600000}} ],
     bitrates: [400000, 600000, 800000],
     method: "bruteForce"
   }; 

--- a/tests/resources/brute-force.test.data.ts
+++ b/tests/resources/brute-force.test.data.ts
@@ -7,6 +7,17 @@ export const defaultFilterFunction: (pair: BitrateResolutionPair) => boolean = (
 
 export const numberOfDefaultBitratesAfterDefaultFilter = 27;
 
+export const jobWithBitratesAndRangeSet: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
+    bitrates: [400000, 600000, 800000],
+    method: "bruteForce"
+  };  
+
 export const jobWithoutBitrates: JobDescription = {
     name: "test-job",
     pipeline: "pipeline.yml",
@@ -29,16 +40,28 @@ export const jobWithoutBitratesAndRange: JobDescription = {
     method: "bruteForce"
   };
 
-export const jobWithBitratesAndRangeSet: JobDescription = {
+  export const jobWithBitratesAndMinRangeSet: JobDescription = {
     name: "test-job",
     pipeline: "pipeline.yml",
     encodingProfile: "profile.json",
     reference: "reference.mp4",
     models: ["HD", "PhoneHD"],
-    resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
+    resolutions: [{ width: 1280, height: 720, range: {min: 600000, max: undefined}} ],
     bitrates: [400000, 600000, 800000],
     method: "bruteForce"
-  };  
+  }; 
+
+  export const jobWithBitratesAndMaxRangeSet: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: {min: undefined, max: 600000}} ],
+    bitrates: [400000, 600000, 800000],
+    method: "bruteForce"
+  }; 
+
 
 export const defaultBitrates = [
     150000,

--- a/tests/resources/brute-force.test.data.ts
+++ b/tests/resources/brute-force.test.data.ts
@@ -1,0 +1,84 @@
+import { JobDescription } from '../../src/create-job';
+import { BitrateResolutionPair } from '../../src/models/bitrate-resolution-pair';
+import { Resolution } from '../../src/models/resolution';
+
+export const defaultFilterFunction: (pair: BitrateResolutionPair) => boolean = ({ bitrate, resolution }) =>
+  bitrate >= resolution.width * resolution.height * 0.3 && bitrate <= resolution.width * resolution.height * 8;
+
+export const numberOfDefaultBitratesAfterDefaultFilter = 27;
+
+export const jobWithoutBitrates: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
+    bitrates: undefined,
+    method: "bruteForce"
+  };
+
+export const jobWithoutBitratesAndRange: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: undefined} ],
+    bitrates: undefined,
+    method: "bruteForce"
+  };
+
+export const jobWithBitratesAndRangeSet: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: {min: 400000, max: 600000}} ],
+    bitrates: [400000, 600000, 800000],
+    method: "bruteForce"
+  };  
+
+export const defaultBitrates = [
+    150000,
+    300000,
+    400000,
+    500000,
+    600000,
+    700000,
+    800000,
+    900000,
+    1000000,
+    1200000,
+    1400000,
+    1600000,
+    1800000,
+    2000000,
+    2200000,
+    2400000,
+    2600000,
+    2800000,
+    3000000,
+    3400000,
+    3800000,
+    4200000,
+    4600000,
+    5000000,
+    5500000,
+    6000000,
+    6500000,
+    7000000,
+    7500000,
+    8000000,
+    8500000,
+    9000000,
+  ];
+
+export const defaultResolutions: Resolution[] = [
+    { width: 640, height: 360, range: undefined},
+    { width: 768, height: 432, range: undefined},
+    { width: 960, height: 540, range: undefined},
+    { width: 1280, height: 720, range: undefined},
+    { width: 1920, height: 1080, range: undefined},
+  ];

--- a/tests/resources/create-job.test.data.ts
+++ b/tests/resources/create-job.test.data.ts
@@ -1,0 +1,73 @@
+import { JobDescription } from '../../src/create-job';
+
+export const job: JobDescription = {
+    name: "test-job",
+    pipeline: "pipeline.yml",
+    encodingProfile: "profile.json",
+    reference: "reference.mp4",
+    models: ["HD", "PhoneHD"],
+    resolutions: [{ width: 1280, height: 720, range: undefined} ],
+    bitrates: [600000],
+    method: "bruteForce"
+  };
+  
+export const pipeline = {
+    aws: {
+      s3Bucket: 'vmaf-files',
+      mediaConvertRole: 'arn:aws:iam::1234:role/MediaConvert_Default_Role',
+      mediaConvertEndpoint: 'https://abc123xyz.mediaconvert.eu-north-1.amazonaws.com',
+      ecsSubnet: 'subnet-05d98882c13408e16',
+      ecsSecurityGroup: 'sg-0e444b67a747bf739',
+      ecsContainerName: 'easyvmaf-s3',
+      ecsCluster: 'vmaf-runner',
+      ecsTaskDefinition: 'easyvmaf-s3:1',
+    },
+  };
+
+export const encodingSettings = {
+    Inputs: [
+      {
+        TimecodeSource: 'ZEROBASED',
+        VideoSelector: {},
+        FileInput: '$INPUT',
+      },
+    ],
+    OutputGroups: [
+      {
+        Name: 'File Group',
+        OutputGroupSettings: {
+          Type: 'FILE_GROUP_SETTINGS',
+          FileGroupSettings: {
+            Destination: '$OUTPUT',
+          },
+        },
+        Outputs: [
+          {
+            VideoDescription: {
+              CodecSettings: {
+                Codec: 'H_265',
+                H265Settings: {
+                  GopBReference: 'ENABLED',
+                  HrdBufferSize: '$HRDBUFFER',
+                  Bitrate: '$BITRATE',
+                  RateControlMode: 'CBR',
+                  CodecProfile: 'MAIN10_HIGH',
+                  AdaptiveQuantization: 'AUTO',
+                  GopSizeUnits: 'AUTO',
+                },
+              },
+              Width: '$WIDTH',
+              Height: '$HEIGHT',
+            },
+            ContainerSettings: {
+              Container: 'MP4',
+              Mp4Settings: {},
+            },
+          },
+        ],
+      },
+    ],
+    TimecodeConfig: {
+      Source: 'ZEROBASED',
+    },
+  };


### PR DESCRIPTION
**Only for brute-force**
It is now possible to filter out bitrates by adding a min and/or max value to the range, which is added under resolution in JobDescription. If min is undefined, it will set the min bitrate to 0. If max is undefined, it will set it to 90000000.
Updated README with some basic information about it as well.

Close #37 