### PR TITLE
fix: correctly check if a file exists before starting transcoding in AWS

### DIFF
--- a/src/pipelines/aws/aws-pipeline.ts
+++ b/src/pipelines/aws/aws-pipeline.ts
@@ -114,7 +114,7 @@ export default class AWSPipeline implements Pipeline {
     const settings = JSON.parse(settingsStr);
     logger.debug('Settings Json: ' + JSON.stringify(settings));
 
-    if (await this.fileExists(`${outputBucket}/${outputFolder}`, outputObject)) {
+    if (await this.fileExists(outputBucket, `${outputFolder}/${outputObject}`)) {
       // File has already been transcoded.
       return outputURI;
     }


### PR DESCRIPTION
Fixes: #47 

This PR fixes a bug where the `fileExists` parameters had been switched from `bucket, key` to `key, bucket`, this resulted in an issue where we would always start a new transcoding even if transcoded files existed in S3.