### PR TITLE
docs: simplify readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ When running with the cli, all transcoding and vmaf analysis will be run locally
 - [FFmpeg](https://www.ffmpeg.org/) >= 5.0, compiled with libvmaf
 - [Python](https://www.python.org) >= 3.0
 
-### Installation
+### Global installation
 
-Installing with `npm -g` will make the `autovmaf` command available in your path
+Installing globally with `npm -g` will make the `autovmaf` command available in your path
 
 ```bash
 npm install -g @eyevinn/autovmaf

--- a/README.md
+++ b/README.md
@@ -1,23 +1,14 @@
-<h1 align="center">
-  <a href="https://github.com/eyevinn/autovmaf">
-    <img src="https://raw.githubusercontent.com/Eyevinn/autovmaf/main/AutoVMAF.svg" alt="Logo" height="100">
-  </a>
-</h1>
-
 <div align="center">
-  autovmaf - A toolkit to automatically encode multiple bitrates and perform automated VMAF measurements on all of them. 
-  <br />
-  <br />
-  :book: <b><a href="https://eyevinn.github.io/autovmaf/">Read the documentation</a></b> :eyes:
-  <br />
-  <br />
-  <a href="https://github.com/eyevinn/autovmaf/issues/new?assignees=&labels=bug&template=01_BUG_REPORT.md&title=bug%3A+">Report a Bug</a>
-  ·
-  <a href="https://github.com/eyevinn/autovmaf/issues/new?assignees=&labels=enhancement&template=02_FEATURE_REQUEST.md&title=feat%3A+">Request a Feature</a>
-</div>
 
-<div align="center">
-<br />
+# [<img src="https://raw.githubusercontent.com/Eyevinn/autovmaf/main/AutoVMAF.svg" alt="autovmaf" height="100">](https://github.com/eyevinn/autovmaf)
+
+autovmaf - A toolkit to automatically encode multiple bitrates and perform automated VMAF measurements on all of them.
+
+📖 **[Read the documentation](https://eyevinn.github.io/autovmaf/)** 👀
+
+[Report a Bug](https://github.com/eyevinn/autovmaf/issues/new?assignees=&labels=bug&template=01_BUG_REPORT.md&title=bug%3A+)
+·
+[Request a Feature](https://github.com/eyevinn/autovmaf/issues/new?assignees=&labels=enhancement&template=02_FEATURE_REQUEST.md&title=feat%3A+)
 
 [![license](https://img.shields.io/npm/v/@eyevinn/autovmaf?style=flat-square)](https://www.npmjs.com/package/@eyevinn/autovmaf)
 [![license](https://img.shields.io/github/v/release/Eyevinn/autovmaf?style=flat-square)](https://github.com/Eyevinn/autovmaf/releases)

--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ Eyevinn Technology is an independent consultant firm specialized in video and st
 
 At Eyevinn, every software developer consultant has a dedicated budget reserved for open source development and contribution to the open source community. This give us room for innovation, team building and personal competence development. And also gives us as a company a way to contribute back to the open source community.
 
-Want to know more about Eyevinn and how it is to work here. Contact us at work@eyevinn.se!
+Want to know more about Eyevinn and how it is to work here. Contact us at <work@eyevinn.se>!


### PR DESCRIPTION
* Use markdown instead of html for the cases when it produces the same output.
* Remove manual line break tags that are not needed (two line breaks is the markdown default)
* Change the header alt text from "logo" to autovmaf. If the logo is replaced with text for a screen reader saying the text in the alt text, it should have the same information as in the image.
* Replaced github specific emojis `:book:` with actual utf-8 emojis, because the github specific ones does not work on https://eyevinn.github.io/autovmaf/.

I had to keep the remaining two elements as html because they have styling.