### PR TITLE
chore: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ npm install -g @eyevinn/autovmaf
 - `EASYVMAF_PATH` - needs to point to the file `easyVmaf.py` from your
   easyVmaf installation.
 - `FFMPEG_PATH` - only needs to be set if ffmpeg is not in your path.
-- `PYTHON_PATH` - only needs to be set if python is not in yur path.
+- `PYTHON_PATH` - only needs to be set if python is not in your path.
 
 ### Command line options
 
@@ -193,9 +193,9 @@ Options:
   --job             File with job definition                            [string]
   --saveAsCsv       Save VMAF measurements as a .csv file in addition to a JSON
                     file                              [boolean] [default: false]
-  --skipTranscode   Skip transcode and run vmaf on allready transcoded files
+  --skipTranscode   Skip transcode and run vmaf on already transcoded files
                                                       [boolean] [default: false]
-  --skipExisting    Skip transcode for allready transcoded files
+  --skipExisting    Skip transcode for already transcoded files
                                                        [boolean] [default: true]
   --probeBitrate    Read bitrate of transcoded file with ffprobe
                                                       [boolean] [default: false]
@@ -209,7 +209,7 @@ If resolutions and/or bitrates are not specified default values will be used, [S
 ### Providing job definition in a json or yaml file
 
 With the `--job` option, a path to a yaml or json file with a job definition can be passed to to the cli. The values
-defined in the file can be overriden with other commandline options. For instance the `reference` video defined
+defined in the file can be overridden with other commandline options. For instance the `reference` video defined
 in the job file can be overridden by passing a source file on the command line.
 
 #### Using variables in the job definition
@@ -245,7 +245,7 @@ pipelineVariables:
 ```
 
 This will run transcode and vmaf analysis for CRF values 22,26,30, and 34. Variables are used in the ffmpeg options
-by insterting `%VARIABLENAME%`. This string will then be subtituted with a value from the list of values from
+by insterting `%VARIABLENAME%`. This string will then be substituted with a value from the list of values from
 `pipelineVariables.VARIABLENAME`. Note that when running CRF encode or other non-ABR mode, `skipDefaultOptions` must
 be set to avoid injecting bitrate options to ffmpeg. Also note that the cli needs to be run with the `--probe-bitrate`
 option to get the correct bitrate from the transcoded files.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "dev": "tsc --watch --project ./",
     "test": "jest",
     "test-coverage": "jest --coverage",
+    "lint:typos": "typos .",
+    "format:typos": "typos -w .",
     "docs": "npx typedoc src/index.ts",
     "postversion": "git push && git push --tags"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,12 +63,12 @@ async function run() {
             skipTranscode: {
               type: 'boolean',
               description:
-                'Skip transcode and run vmaf on allready transcoded files',
+                'Skip transcode and run vmaf on already transcoded files',
               default: false
             },
             skipExisting: {
               type: 'boolean',
-              description: 'Skip transcode for allready transcoded files',
+              description: 'Skip transcode for already transcoded files',
               default: true
             },
             probeBitrate: {
@@ -184,7 +184,7 @@ async function transcodeAndAnalyse(argv) {
 }
 
 async function updateJobDefinition(argv) {
-  const job: any = argv.job ? await readJobDefintion(argv.job) : {};
+  const job: any = argv.job ? await readJobDefinition(argv.job) : {};
   job.skipTranscode = argv.skipTranscode;
   job.skipExisting = argv.skipExisting;
   if (argv.source) {
@@ -237,7 +237,7 @@ async function updateJobDefinition(argv) {
   return job;
 }
 
-async function readJobDefintion(file) {
+async function readJobDefinition(file) {
   const text = await fs.readFile(file, { encoding: 'utf-8' });
   const extension = path.extname(file);
   const definition = ['.yml', '.yaml'].includes(extension.toLowerCase())

--- a/src/create-job.ts
+++ b/src/create-job.ts
@@ -44,10 +44,10 @@ export type JobDescription = {
   /** Values that will be substituted into the encoding options. Currently only supported for local pipeline */
   pipelineVariables?: { [key: string]: string[] };
 
-  /** Skip transcode and run analysis only, files are assumed to be allready present */
+  /** Skip transcode and run analysis only, files are assumed to be already present */
   skipTranscode?: boolean;
 
-  /** Skip transcode if outfile allready exists */
+  /** Skip transcode if outfile already exists */
   skipExisting?: boolean;
 };
 

--- a/src/get-vmaf.ts
+++ b/src/get-vmaf.ts
@@ -46,7 +46,7 @@ async function dataFromS3(
     const getCommands = listResponse.Contents?.map(
       (obj) => new GetObjectCommand({ Bucket: bucket, Key: obj.Key })
     );
-    const getReponses = getCommands
+    const getResponses = getCommands
       .filter((command) => command.input.Key?.endsWith('.json'))
       .map(async (command) => {
         const response = await s3.send(command);
@@ -54,13 +54,13 @@ async function dataFromS3(
       });
 
     let counter = 1;
-    for (const promise of getReponses) {
+    for (const promise of getResponses) {
       const { key, response } = await promise;
       const stream = (await response).Body;
       const data = await streamToString(stream);
       dataList.push({ filename: path.basename(key), contents: data });
-      onProgress(counter - 1, path.basename(key), getReponses.length);
-      logger.info(`Finished loading VMAF ${counter}/${getReponses.length}.`);
+      onProgress(counter - 1, path.basename(key), getResponses.length);
+      logger.info(`Finished loading VMAF ${counter}/${getResponses.length}.`);
       counter += 1;
     }
   }


### PR DESCRIPTION
Ran a typo checker and that auto-fixed some typos.

Not sure if we should enforce this. It's written in rust and there is no official npm package: https://github.com/crate-ci/typos

So I added the scripts, but nothing to enforce the check.